### PR TITLE
Deploy to s3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: deploy
+    steps:
+    - uses: actions/checkout@v1
+    - uses: haskell/actions/setup@v1
+      with:
+        ghc-version: '8.10.3'
+        enable-stack: true
+        stack-version: '2.5.1'
+    - name: Cache stack global package db and installed programs
+      uses: actions/cache@v2
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-${{ matrix.ghc }}
+    - name: Build
+      run: |
+        stack build
+    - name: Build site
+      run: |
+        stack exec site build
+    - name: Upload to S3
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --delete
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_REGION: ${{ secrets.AWS_S3_BUCKET_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: '_site'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         stack exec site build
     - name: Upload to S3
-      uses: jakejarvis/s3-sync-action@master
+      uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
       with:
         args: --delete
       env:


### PR DESCRIPTION
Before merging, we should figure out where this is getting hosted — then we need to set up the secrets used in this `deploy` action. Is a domain figured out yet @kmarekspartz ?

I tested this with a bucket I set up and a cloudfront distribution in front of it. For reference, the iam permissions I gave were:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "AccessToReadWriteHaskellMnS3Bucket",
            "Effect": "Allow",
            "Action": [
                "s3:PutObject",
                "s3:GetObject",
                "s3:DeleteObject"
            ],
            "Resource": "arn:aws:s3:::BUCKET_NAME/*"
        },
        {
            "Sid": "AccessToListHaskellMnS3Bucket",
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket"
            ],
            "Resource": "arn:aws:s3:::BUCKET_NAME"
        }
    ]
}
```

The cloudfront distribution is here: https://haskellmn.chorebot.consulting

To do before merge:
- [ ] Figure out what s3 bucket we're deploying to. Add an iam user with the permissions above and get keys.
- [ ] Create `deploy` environment here: https://github.com/HaskellMN/www.haskell.mn/settings/environments
- [ ] Add in secrets to the `deploy` environment needed for the deploy action: `AWS_S3_BUCKET`, `AWS_S3_BUCKET_REGION`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`